### PR TITLE
In README, make the precondition-checking solution more noticeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ fzy.positions("amuser", "app/models/customer.rb") // [ 0, 4, 12, 13, 17, 18 ]
 
 NB: `score` and `positions` must be called with matching needle and haystack,
 doing otherwise is undefined. The caller needs to check that there is a match.
+See the full example below for a way to do this check.
 
 
 # Full Example


### PR DESCRIPTION
The lack of a given solution to the problem “the caller needs to check that there is a match” almost scared me away from this library. I only found the solution by looking [in the code of fzy-demo](https://github.com/jhawthorn/fzy-demo/blob/f20cff22faa6fb1c0871b437b6b3e0c16ac5e194/src/App.js#L11-L15) – it didn’t occur to me to look for the solution within the full example until after I had started trying to edit this README to add the relevant part of fzy-demo’s code. This sentence right after the warning should make it clear that the precondition is not as hard to satisfy as it sounds.